### PR TITLE
Add QR code for shortened url

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -205,7 +205,7 @@ input::placeholder {
   align-items: center;
   padding: 0 20px 0 70px;
   width: 100%;
-  height: 78px;
+  height: 85px;
   border: 1px solid #ECF1FB;
   border-radius: 8px;
   background-image: url(/img/cut_gray.svg);
@@ -288,6 +288,10 @@ body.in-progress .cut-button .loader {
   color: #4779FF;
 }
 
+.qr-code {
+  height: 100%;
+}
+
 @media(max-width: 600px) {
   .link-input-wrapper {
     height: 150px;
@@ -322,12 +326,17 @@ body.in-progress .cut-button .loader {
   }
 
   .result-item {
-    height: 180px;
+    height: 300px;
     justify-content: space-between;
     flex-direction: column;
     padding: 25px 10px;
+    padding-bottom: 0px;
     background-image: none;
     margin-bottom: 10px;
+  }
+
+  .qr-code {
+    height: 50%;
   }
 
   .result-item.result-error {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -62,13 +62,21 @@ async function cut() {
     return showError(error);
   }
 
+  const completeURL = `https://kes.im/${data.shortLink}`;
+
   resultList.insertAdjacentHTML('afterbegin', `
     <li class="result-item">
-      <a target="_blank" rel="nofollow" href="https://kes.im/${data.shortLink}">
+      <a target="_blank" rel="nofollow" href="${completeURL}">
         https://kes.im/${cutString(data.shortLink, 40)}
       </a>
       <div class="original-url">${cutString(url, 40)}</div>
       <button class="copy-button" onclick="copy(event, '${data.shortLink}')">Copy URL</button>
+      <img 
+        class="qr-code"
+        alt="QR Code"
+        loading="lazy"
+        src="https://chart.googleapis.com/chart?chs=200x200&cht=qr&chl=${completeURL}&choe=UTF-8"
+      />
     </li>
   `);
 


### PR DESCRIPTION
I wanted to add such a feature because I also need QR code images of the shortened links created.

**Preview**
![image](https://github.com/ramesaliyev/kes.im/assets/55887158/46f955e8-bf7d-4e3b-ac05-504f49b1eaf1)


P.S: I used https://developers.google.com/chart to generate QR images, it's free.